### PR TITLE
Ignore secrets files on command line

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -782,14 +782,15 @@ def run_esphome(argv):
         )
         return 1
 
-    for secret in CONF_SECRETS:
-        if secret.casefold() in (config.casefold() for config in args.configuration):
-            _LOGGER.warning("%s was specified on the command line. Skipping...", secret)
-            args.configuration[:] = [
-                conf
-                for conf in args.configuration
-                if conf.casefold() != secret.casefold()
-            ]
+    if hasattr(args, 'configuration'):
+        for secret in CONF_SECRETS:
+            if secret.casefold() in (config.casefold() for config in args.configuration):
+                _LOGGER.warning("%s was specified on the command line. Skipping...", secret)
+                args.configuration[:] = [
+                    conf
+                    for conf in args.configuration
+                    if conf.casefold() != secret.casefold()
+                ]
 
     if args.command in PRE_CONFIG_ACTIONS:
         try:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -18,6 +18,7 @@ from esphome.const import (
     CONF_PORT,
     CONF_ESPHOME,
     CONF_PLATFORMIO_OPTIONS,
+    CONF_SECRETS,
 )
 from esphome.core import CORE, EsphomeError, coroutine
 from esphome.helpers import indent
@@ -780,6 +781,15 @@ def run_esphome(argv):
             "with this Python version. Please reinstall ESPHome with Python 3.7+"
         )
         return 1
+
+    for secret in CONF_SECRETS:
+        if secret.casefold() in (config.casefold() for config in args.configuration):
+            _LOGGER.warning(f"{secret} was specified on the command line. Skipping...")
+            args.configuration[:] = [
+                conf
+                for conf in args.configuration
+                if conf.casefold() != secret.casefold()
+            ]
 
     if args.command in PRE_CONFIG_ACTIONS:
         try:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -784,7 +784,7 @@ def run_esphome(argv):
 
     for secret in CONF_SECRETS:
         if secret.casefold() in (config.casefold() for config in args.configuration):
-            _LOGGER.warning(f"{secret} was specified on the command line. Skipping...")
+            _LOGGER.warning("%s was specified on the command line. Skipping...", secret)
             args.configuration[:] = [
                 conf
                 for conf in args.configuration

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -201,8 +201,7 @@ def upload_using_esptool(config, port):
         firmware_offset = "0x10000" if CORE.is_esp32 else "0x0"
         flash_images = [
             platformio_api.FlashImage(
-                path=idedata.firmware_bin_path,
-                offset=firmware_offset,
+                path=idedata.firmware_bin_path, offset=firmware_offset
             ),
             *idedata.extra_flash_images,
         ]
@@ -608,10 +607,7 @@ def parse_args(argv):
         "wizard",
         help="A helpful setup wizard that will guide you through setting up ESPHome.",
     )
-    parser_wizard.add_argument(
-        "configuration",
-        help="Your YAML configuration file.",
-    )
+    parser_wizard.add_argument("configuration", help="Your YAML configuration file.")
 
     parser_fingerprint = subparsers.add_parser(
         "mqtt-fingerprint", help="Get the SSL fingerprint from a MQTT broker."
@@ -633,8 +629,7 @@ def parse_args(argv):
         "dashboard", help="Create a simple web server for a dashboard."
     )
     parser_dashboard.add_argument(
-        "configuration",
-        help="Your YAML configuration file directory.",
+        "configuration", help="Your YAML configuration file directory."
     )
     parser_dashboard.add_argument(
         "--port",
@@ -782,10 +777,14 @@ def run_esphome(argv):
         )
         return 1
 
-    if hasattr(args, 'configuration'):
+    if hasattr(args, "configuration"):
         for secret in CONF_SECRETS:
-            if secret.casefold() in (config.casefold() for config in args.configuration):
-                _LOGGER.warning("%s was specified on the command line. Skipping...", secret)
+            if secret.casefold() in (
+                config.casefold() for config in args.configuration
+            ):
+                _LOGGER.warning(
+                    "%s was specified on the command line. Skipping...", secret
+                )
                 args.configuration[:] = [
                     conf
                     for conf in args.configuration

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -33,7 +33,7 @@ ARDUINO_VERSION_ESP8266 = {
 }
 SOURCE_FILE_EXTENSIONS = {".cpp", ".hpp", ".h", ".c", ".tcc", ".ino"}
 HEADER_FILE_EXTENSIONS = {".h", ".hpp", ".tcc"}
-SECRETS_FILES = {"secrets.yaml", "secrets.yml" }
+SECRETS_FILES = {"secrets.yaml", "secrets.yml"}
 
 
 CONF_ABOVE = "above"

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -33,6 +33,7 @@ ARDUINO_VERSION_ESP8266 = {
 }
 SOURCE_FILE_EXTENSIONS = {".cpp", ".hpp", ".h", ".c", ".tcc", ".ino"}
 HEADER_FILE_EXTENSIONS = {".h", ".hpp", ".tcc"}
+SECRETS_FILES = {"secrets.yaml", "secrets.yml" }
 
 
 CONF_ABOVE = "above"
@@ -591,7 +592,6 @@ CONF_SDA = "sda"
 CONF_SDO_PIN = "sdo_pin"
 CONF_SECOND = "second"
 CONF_SECONDS = "seconds"
-CONF_SECRETS = ["secrets.yaml", "secrets.yml"]
 CONF_SECURITY_LEVEL = "security_level"
 CONF_SEGMENTS = "segments"
 CONF_SEL_PIN = "sel_pin"

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -591,6 +591,7 @@ CONF_SDA = "sda"
 CONF_SDO_PIN = "sdo_pin"
 CONF_SECOND = "second"
 CONF_SECONDS = "seconds"
+CONF_SECRETS = ["secrets.yaml", "secrets.yml"]
 CONF_SECURITY_LEVEL = "security_level"
 CONF_SEGMENTS = "segments"
 CONF_SEL_PIN = "sel_pin"


### PR DESCRIPTION
When ``esphome`` is run from the CLI to update a subset of the configuration files, or all of them, the ``secrets.yaml`` file - when specified - yields an error. This makes it hard to do, for instance, ``esphome upload *yaml``. This makes sure to skip the files ``secrets.yaml`` and ``secrets.yml`` when specified on the command line.

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
